### PR TITLE
handle query string inside mpdFileURL

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -590,8 +590,12 @@ bool Session::initialize()
     xbmc->Log(ADDON::LOG_ERROR, "Invalid mpdURL: / expected (%s)", mpdFileURL_.c_str());
     return false;
   }
-  dashtree_.base_url_ = std::string(mpdFileURL_.c_str(), (delim - mpdFileURL_.c_str()) + 1);
-
+  
+  size_t pos = mpdFileURL_.find_last_of('?', mpdFileURL_.length());
+  if (pos == std::string::npos)
+    pos = mpdFileURL_.length();
+  dashtree_.base_url_ = mpdFileURL_.substr(0, mpdFileURL_.find_last_of('/', pos) + 1);
+  
   if (!dashtree_.open(mpdFileURL_.c_str()) || dashtree_.empty())
   {
     xbmc->Log(ADDON::LOG_ERROR, "Could not open / parse mpdURL (%s)", mpdFileURL_.c_str());


### PR DESCRIPTION
Sometimes a query string is added to the Manifest url which includes a slash e.g.:
http://webclipssky-s.akamaihd.net/ondemand/1059/prod/20160813222724_tipico_4_SVR_RBS/20160813222724_tipico_4_SVR_RBS.ism/Manifest?hdnea=st=1471144790~exp=1471144820~acl=/*~hmac=a299e040f09e629c5d777238d7b1598d549ef9c61ddd775fa43a5229494d0758

In that case, the dashtree_.base_url_ will be wrong. This commit simply checks for a query string and builds the baseurl from mpdFileURL leaving it out.